### PR TITLE
Fix the IIFE format

### DIFF
--- a/assets/js/plugins.js
+++ b/assets/js/plugins.js
@@ -19,4 +19,4 @@
             console[method] = noop;
         }
     }
-}());
+})();


### PR DESCRIPTION
The JavaScript immediately-invoked function expression typically places the parenthesis for the invocation outside of the parenthesis that wrap the function defintion.
